### PR TITLE
Add code of conduct

### DIFF
--- a/general/CODE_OF_CONDUCT.md
+++ b/general/CODE_OF_CONDUCT.md
@@ -1,0 +1,70 @@
+# General Code of Conduct
+
+freeCodeCamp Nashville is a community intended to provide a safe space for professional networking, education, and collaboration in the local Nashville developer community.
+
+We value the participation of each member of the freeCodeCamp Nashville community and want all of our community members to have enjoyable and fulfilling experiences. Accordingly, all attendees are expected to show respect and courtesy to other community members both online and in person.
+
+To make clear what is expected, all freeCodeCamp Nashville organizers, speakers, sponsors, and community members are required to conform to the following Code of Conduct. Organizers will enforce this code during all freeCodeCamp Nashville meetings as well as in any official online discussion channels.
+
+## Our Standards
+
+freeCodeCamp Nashville is dedicated to providing a positive, harassment-free environment for everyone, regardless of gender, gender identity or expression, sexual orientation, disability, physical appearance, body size, ethnicity, nationality, race, age, religion (or lack thereof), education, or socio-economic status. We do not tolerate harassment of participants in any form.
+
+Examples of harassment include, but are not limited to:
+
+- Verbal harassment in any form of community members
+- Written harassment including on any electronic media or communication channel
+- Deliberate intimidation, stalking, or following
+- Violent threats or language directed against another person
+- Sexual language and imagery in any event venue or communication channel
+- Harassing photography or recording
+- Sustained disruption of talks or other events
+- Inappropriate or unwelcome physical contact
+- Unwelcome sexual attention or advances
+- Advocating for, or encouraging, any of the above behaviour
+
+Members asked to stop any inappropriate behavior are expected to comply immediately.
+
+If a community member violates these rules, the organizers may take any action they deem appropriate, including issuing a warning or banning the member from the community permanently.
+
+We appreciate your help in making freeCodeCamp Nashville a welcoming, friendly, professional space for everyone.
+
+## Scope
+
+All freeCodeCamp Nashville community members are subject to this Code of Conduct. This includes freeCodeCamp Nashville organizers and speakers. In addition, all sponsors and vendors are subject to this Code of Conduct as well.
+
+Where freeCodeCamp Nashville platforms or events are subject to their own Code of Conduct (e.g. the [Discord Parnership Code of Conduct](https://support.discordapp.com/hc/en-us/articles/360024871991-Discord-Partnership-Code-of-Conduct)) both Code of Conducts will be enforced. If there are any conflicts between the two, priority will be given to the third party Code of Conduct freeCodeCamp Nashville is subject to in these instances.
+
+## Reporting Guidelines
+
+If you believe that someone is violating the code of conduct in an official freeCodeCamp Nashville space, or witness someone violating this code of conduct, please contact an organizer immediately. You may report the violation in a number of ways:
+
+- By finding an organizer and reporting in person
+- Contacting in organizer directly, or corporately, via email:
+  - Seth Alexander: sethalexander@pm.me
+  - Dave Harned: dharned@gmail.com
+  - Laura Pinell: laura@uxbridge.io
+- All reports will be kept confidential.** In some cases we may determine that a public statement will need to be made. In those cases, the identities of all victims, reporters, and the accused will remain confidential unless those individuals instruct us otherwise.
+
+Organizers will be happy to help members contact local law enforcement, provide escorts, or otherwise assist any attendee to feel safe for the duration of any event. We value your presence.
+
+When making a report, please include:
+
+- Your contact info for follow-up contact.
+- Names (legal, nicknames, or pseudonyms) of any individuals involved.
+- If there were other witnesses besides you, please try to include them as well.
+- When and where the incident occurred. Please be as specific as possible.
+- Your account of what occurred.
+- If there is a publicly available record (e.g. an email archive or a public Slack log) please include a link.
+- Any extra context you believe existed for the incident.
+- If you believe this incident is ongoing.
+- Any other information you believe we should have.
+
+## Appeals
+
+Only permanent actions (such as bans) may be appealed. To appeal a decision, please contact an organizer listed above with your appeal and freeCodeCamp Nashville will review the case.
+License
+
+This code of conduct was originally derived from the [PyNash Code of Conduct](https://pynash.org/code-of-conduct).
+
+The freeCodeCamp Nashville Code of Conduct is similarly licensed under a [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).


### PR DESCRIPTION
This is a **almost** carbon copy of the document that was worked on previously.  The one change is I added the second paragraph to the Scope section. The idea being if there's a field trip to NashJS or something and they have their own CoC we can't just superseded that. This CoC will fall second to theirs and any others that we interact with.